### PR TITLE
Next Planned Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 A TCP client implementation with working timeout support.
 
 ## Description
-This gem implements a TCP client with (optional) SSL support. The motivation of this project is the need to have a _really working_ easy to use client which can handle time limits correctly. Unlike other implementations this client respects given/configurable time limits for each method (`connect`, `read`, `write`).
+
+This Gem implements a TCP client with (optional) SSL support. It is an easy to use, versatile configurable client that can correctly handle time limits. Unlike other implementations, this client respects predefined/configurable time limits for each method (`connect`, `read`, `write`). Deadlines for a sequence of read/write actions can also be monitored.
 
 ## Sample
 
@@ -11,15 +12,16 @@ This gem implements a TCP client with (optional) SSL support. The motivation of 
 require 'tcp-client'
 
 TCPClient.configure do |cfg|
-  cfg.connect_timeout = 1 # second to connect the server
+  cfg.connect_timeout = 1 # limit connect time the server to 1 second
   cfg.ssl_params = { ssl_version: :TLSv1_2 } # use TLS 1.2
 end
 
 TCPClient.open('www.google.com:443') do |client|
-  # query should not last longer than 0.5 seconds
+  # next sequence should not last longer than 0.5 seconds
   client.with_deadline(0.5) do
+
     # simple HTTP get request
-    pp client.write("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")
+    pp client.write("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n")
 
     # read "HTTP/1.1 " + 3 byte HTTP status code
     pp client.read(12)

--- a/lib/tcp-client/deadline.rb
+++ b/lib/tcp-client/deadline.rb
@@ -1,0 +1,26 @@
+class TCPClient
+  class Deadline < BasicObject
+    if defined?(Process::CLOCK_MONOTONIC)
+      def initialize(timeout)
+        @deadline = timeout + Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      def remaining_time
+        @deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    else
+      def initialize(timeout)
+        @deadline = ::Time.now + timeout
+      end
+
+      def remaining_time
+        @deadline - ::Time.now
+      end
+    end
+
+    def remaining(exception)
+      (time = remaining_time) > 0 ? time : ::Kernel.raise(exception)
+    end
+    alias remaining? remaining
+  end
+end

--- a/lib/tcp-client/ssl_socket.rb
+++ b/lib/tcp-client/ssl_socket.rb
@@ -4,6 +4,7 @@ rescue LoadError
   return
 end
 
+require_relative 'deadline'
 require_relative 'mixin/io_with_deadline'
 
 class TCPClient
@@ -12,8 +13,8 @@ class TCPClient
 
     def initialize(socket, address, configuration, exception)
       ssl_params = Hash[configuration.ssl_params]
-      self.sync_close = true
       super(socket, create_context(ssl_params))
+      self.sync_close = true
       connect_to(
         address,
         ssl_params[:verify_mode] != OpenSSL::SSL::VERIFY_NONE,
@@ -36,7 +37,7 @@ class TCPClient
       if timeout.zero?
         connect
       else
-        with_deadline(Time.now + timeout, exception) do
+        with_deadline(Deadline.new(timeout), exception) do
           connect_nonblock(exception: false)
         end
       end

--- a/lib/tcp-client/tcp_socket.rb
+++ b/lib/tcp-client/tcp_socket.rb
@@ -1,4 +1,5 @@
 require 'socket'
+require_relative 'deadline'
 require_relative 'mixin/io_with_deadline'
 
 class TCPClient
@@ -21,7 +22,7 @@ class TCPClient
         )
       timeout = timeout.to_f
       return connect(addr) if timeout.zero?
-      with_deadline(Time.now + timeout, exception) do
+      with_deadline(Deadline.new(timeout), exception) do
         connect_nonblock(addr, exception: false)
       end
     end

--- a/sample/google.rb
+++ b/sample/google.rb
@@ -14,7 +14,7 @@ TCPClient.configure(
 
 TCPClient.open('www.google.com:80') do |client|
   # simple HTTP get request
-  pp client.write("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")
+  pp client.write("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n")
 
   # read "HTTP/1.1 " + 3 byte HTTP status code
   pp client.read(12)

--- a/sample/google.rb
+++ b/sample/google.rb
@@ -6,8 +6,7 @@ TCPClient.configure(
   read_timeout: 0.5 # seconds to read some bytes
 )
 
-# the following request sequence is not allowed
-# to last longer than 1.25 seconds:
+# the following sequence is not allowed to last longer than 1.25 seconds:
 #   0.5 seconds to connect
 # + 0.25 seconds to write data
 # + 0.5 seconds to read a response

--- a/sample/google_ssl.rb
+++ b/sample/google_ssl.rb
@@ -9,7 +9,7 @@ TCPClient.open('www.google.com:443') do |client|
   # query should not last longer than 0.5 seconds
   client.with_deadline(0.5) do
     # simple HTTP get request
-    pp client.write("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")
+    pp client.write("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n")
 
     # read "HTTP/1.1 " + 3 byte HTTP status code
     pp client.read(12)

--- a/sample/google_ssl.rb
+++ b/sample/google_ssl.rb
@@ -1,13 +1,14 @@
 require_relative '../lib/tcp-client'
 
 TCPClient.configure do |cfg|
-  cfg.connect_timeout = 1 # second to connect the server
+  cfg.connect_timeout = 1 # limit connect time the server to 1 second
   cfg.ssl_params = { ssl_version: :TLSv1_2 } # use TLS 1.2
 end
 
 TCPClient.open('www.google.com:443') do |client|
-  # query should not last longer than 0.5 seconds
+  # next sequence should not last longer than 0.5 seconds
   client.with_deadline(0.5) do
+
     # simple HTTP get request
     pp client.write("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n")
 

--- a/tcp-client.gemspec
+++ b/tcp-client.gemspec
@@ -11,11 +11,13 @@ GemSpec = Gem::Specification.new do |spec|
 
   spec.summary = 'A TCP client implementation with working timeout support.'
   spec.description = <<~DESCRIPTION
-    This gem implements a TCP client with (optional) SSL support. The
-    motivation of this project is the need to have a _really working_
-    easy to use client which can handle time limits correctly. Unlike
-    other implementations this client respects given/configurable time
-    limits for each method (`connect`, `read`, `write`).
+    This Gem implements a TCP client with (optional) SSL support.
+    It is an easy to use, versatile configurable client that can correctly
+    handle time limits.
+    Unlike other implementations, this client respects
+    predefined/configurable time limits for each method
+    (`connect`, `read`, `write`). Deadlines for a sequence of read/write
+    actions can also be monitored.
   DESCRIPTION
   spec.homepage = 'https://github.com/mblumtritt/tcp-client'
 


### PR DESCRIPTION
* Use monotonic clock when supported
   To reduce overhead and speed things up the monotonic clock will be used when supported (see documentation for `Process::CLOCK_MONOTONIC`). The `Time` based method will be used as fallback.
* Correct addresses for Google samples
   Google forwards to www.google.com when the server google.com is specified in the HTTP header \o/
* Extend gem description