### PR TITLE
Use monotonic clock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.local/
+local/
 tmp/
 pkg/
 gems.locked

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 A TCP client implementation with working timeout support.
 
 ## Description
-This gem implements a TCP client with (optional) SSL support. The motivation of this project is the need to have a _really working_ easy to use client which can handle time limits correctly. Unlike other implementations this client respects given/configurable time limits for each method (`connect`, `read`, `write`).
+
+This Gem implements a TCP client with (optional) SSL support. It is an easy to use, versatile configurable client that can correctly handle time limits. Unlike other implementations, this client respects predefined/configurable time limits for each method (`connect`, `read`, `write`). Deadlines for a sequence of read/write actions can also be monitored.
 
 ## Sample
 
@@ -11,15 +12,15 @@ This gem implements a TCP client with (optional) SSL support. The motivation of 
 require 'tcp-client'
 
 TCPClient.configure do |cfg|
-  cfg.connect_timeout = 1 # second to connect the server
+  cfg.connect_timeout = 1 # limit connect time the server to 1 second
   cfg.ssl_params = { ssl_version: :TLSv1_2 } # use TLS 1.2
 end
 
 TCPClient.open('www.google.com:443') do |client|
-  # query should not last longer than 0.5 seconds
+  # next sequence should not last longer than 0.5 seconds
   client.with_deadline(0.5) do
     # simple HTTP get request
-    pp client.write("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")
+    pp client.write("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n")
 
     # read "HTTP/1.1 " + 3 byte HTTP status code
     pp client.read(12)

--- a/lib/tcp-client/address.rb
+++ b/lib/tcp-client/address.rb
@@ -58,10 +58,7 @@ class TCPClient
 
     def from_string(str)
       idx = str.rindex(':') or return nil, str.to_i
-      name = str[0, idx]
-      if name.start_with?('[') && name.end_with?(']')
-        name = name[1, name.size - 2]
-      end
+      name = str[0, idx].delete_prefix('[').delete_suffix(']')
       [name, str[idx + 1, str.size - idx].to_i]
     end
   end

--- a/lib/tcp-client/configuration.rb
+++ b/lib/tcp-client/configuration.rb
@@ -13,7 +13,6 @@ class TCPClient
     attr_reader :buffered,
                 :keep_alive,
                 :reverse_lookup,
-                :timeout,
                 :connect_timeout,
                 :read_timeout,
                 :write_timeout,
@@ -47,9 +46,12 @@ class TCPClient
     end
 
     def ssl=(value)
-      return @ssl_params = nil unless value
-      return @ssl_params = value.dup if Hash === value
-      @ssl_params ||= {}
+      @ssl_params =
+        if Hash === value
+          value.dup
+        else
+          value ? {} : nil
+        end
     end
 
     def buffered=(value)
@@ -65,8 +67,7 @@ class TCPClient
     end
 
     def timeout=(seconds)
-      @timeout =
-        @connect_timeout = @write_timeout = @read_timeout = seconds(seconds)
+      @connect_timeout = @write_timeout = @read_timeout = seconds(seconds)
     end
 
     def connect_timeout=(seconds)
@@ -107,7 +108,6 @@ class TCPClient
         buffered: @buffered,
         keep_alive: @keep_alive,
         reverse_lookup: @reverse_lookup,
-        timeout: @timeout,
         connect_timeout: @connect_timeout,
         read_timeout: @read_timeout,
         write_timeout: @write_timeout,

--- a/lib/tcp-client/deadline.rb
+++ b/lib/tcp-client/deadline.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class TCPClient
+  class Deadline
+    MONOTONIC = !!defined?(Process::CLOCK_MONOTONIC)
+
+    def initialize(timeout)
+      timeout = timeout&.to_f
+      @deadline = timeout&.positive? ? now + timeout : 0
+    end
+
+    def valid?
+      @deadline != 0
+    end
+
+    def remaining_time
+      (@deadline != 0) && (remaining = @deadline - now) > 0 ? remaining : nil
+    end
+
+    private
+
+    if MONOTONIC
+      def now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    else
+      def now
+        ::Time.now
+      end
+    end
+  end
+end

--- a/lib/tcp-client/default_configuration.rb
+++ b/lib/tcp-client/default_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'configuration'
 
 class TCPClient

--- a/lib/tcp-client/tcp_socket.rb
+++ b/lib/tcp-client/tcp_socket.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 require 'socket'
+require_relative 'deadline'
 require_relative 'mixin/io_with_deadline'
 
 class TCPClient
@@ -19,9 +22,9 @@ class TCPClient
           address.addrinfo.ip_port,
           address.addrinfo.ip_address
         )
-      timeout = timeout.to_f
-      return connect(addr) if timeout.zero?
-      with_deadline(Time.now + timeout, exception) do
+      deadline = Deadline.new(timeout)
+      return connect(addr) unless deadline.valid?
+      with_deadline(deadline, exception) do
         connect_nonblock(addr, exception: false)
       end
     end

--- a/lib/tcp-client/version.rb
+++ b/lib/tcp-client/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TCPClient
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.4.0'
 end

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -11,7 +11,6 @@ CLOBBER << 'prj'
 task(:default) { exec('rake --tasks') }
 
 Rake::TestTask.new(:test) do |task|
-  task.test_files = FileList['test/**/*_test.rb']
-  task.ruby_opts = %w[-w]
-  task.verbose = true
+  task.pattern = 'test/**/*_test.rb'
+  task.warning = task.verbose = true
 end

--- a/sample/google.rb
+++ b/sample/google.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../lib/tcp-client'
 
 TCPClient.configure(
@@ -6,15 +8,14 @@ TCPClient.configure(
   read_timeout: 0.5 # seconds to read some bytes
 )
 
-# the following request sequence is not allowed
-# to last longer than 1.25 seconds:
+# the following sequence is not allowed to last longer than 1.25 seconds:
 #   0.5 seconds to connect
 # + 0.25 seconds to write data
 # + 0.5 seconds to read a response
 
 TCPClient.open('www.google.com:80') do |client|
   # simple HTTP get request
-  pp client.write("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")
+  pp client.write("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n")
 
   # read "HTTP/1.1 " + 3 byte HTTP status code
   pp client.read(12)

--- a/sample/google_ssl.rb
+++ b/sample/google_ssl.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 require_relative '../lib/tcp-client'
 
 TCPClient.configure do |cfg|
-  cfg.connect_timeout = 1 # second to connect the server
+  cfg.connect_timeout = 1 # limit connect time the server to 1 second
   cfg.ssl_params = { ssl_version: :TLSv1_2 } # use TLS 1.2
 end
 
 TCPClient.open('www.google.com:443') do |client|
-  # query should not last longer than 0.5 seconds
+  # next sequence should not last longer than 0.5 seconds
   client.with_deadline(0.5) do
     # simple HTTP get request
-    pp client.write("GET / HTTP/1.1\r\nHost: google.com\r\n\r\n")
+    pp client.write("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n")
 
     # read "HTTP/1.1 " + 3 byte HTTP status code
     pp client.read(12)

--- a/tcp-client.gemspec
+++ b/tcp-client.gemspec
@@ -11,11 +11,13 @@ GemSpec = Gem::Specification.new do |spec|
 
   spec.summary = 'A TCP client implementation with working timeout support.'
   spec.description = <<~DESCRIPTION
-    This gem implements a TCP client with (optional) SSL support. The
-    motivation of this project is the need to have a _really working_
-    easy to use client which can handle time limits correctly. Unlike
-    other implementations this client respects given/configurable time
-    limits for each method (`connect`, `read`, `write`).
+    This Gem implements a TCP client with (optional) SSL support.
+    It is an easy to use, versatile configurable client that can correctly
+    handle time limits.
+    Unlike other implementations, this client respects
+    predefined/configurable time limits for each method
+    (`connect`, `read`, `write`). Deadlines for a sequence of read/write
+    actions can also be monitored.
   DESCRIPTION
   spec.homepage = 'https://github.com/mblumtritt/tcp-client'
 

--- a/test/tcp-client/address_test.rb
+++ b/test/tcp-client/address_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../test_helper'
 
 class AddressTest < MiniTest::Test

--- a/test/tcp-client/configuration_test.rb
+++ b/test/tcp-client/configuration_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../test_helper'
 
 class ConfigurationTest < MiniTest::Test

--- a/test/tcp-client/deadline_test.rb
+++ b/test/tcp-client/deadline_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class Deadlineest < MiniTest::Test
+  parallelize_me!
+
+  def test_validity
+    assert(TCPClient::Deadline.new(1).valid?)
+    assert(TCPClient::Deadline.new(0.0001).valid?)
+
+    refute(TCPClient::Deadline.new(0).valid?)
+    refute(TCPClient::Deadline.new(nil).valid?)
+  end
+
+  def test_remaining_time
+    assert(TCPClient::Deadline.new(1).remaining_time > 0)
+
+    assert_nil(TCPClient::Deadline.new(0).remaining_time)
+    assert_nil(TCPClient::Deadline.new(nil).remaining_time)
+
+    deadline = TCPClient::Deadline.new(0.2)
+    sleep(0.2)
+    assert_nil(deadline.remaining_time)
+  end
+end

--- a/test/tcp-client/version_test.rb
+++ b/test/tcp-client/version_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../test_helper'
 
 class VersionTest < MiniTest::Test

--- a/test/tcp_client_test.rb
+++ b/test/tcp_client_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'test_helper'
 
 class TCPClientTest < MiniTest::Test


### PR DESCRIPTION
To reduce overhead and speed things up the monotonic clock will be used when supported (see documentation for `Process::CLOCK_MONOTONIC`).

- `Time` based method will be used as fallback
- `Configuration#to_h` will not longer contain `timeout`
- reduce overhead in `IOWithDeadlineMixin`