### PR TITLE
Add #readline method

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,14 @@ cfg = TCPClient::Configuration.create(
 # - limit all network interactions to 1.5 seconds
 # - use the Configuration cfg
 # - send a simple HTTP get request
-# - read 12 byte: "HTTP/1.1 " + 3 byte HTTP status code
-TCPClient.with_deadline(1.5, 'www.google.com:443', cfg) do |client|
-  client.write("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n") # >= 40
-  client.read(12) # => "HTTP/1.1 200"
-end
+# - read the returned message and headers
+response =
+  TCPClient.with_deadline(1.5, 'www.google.com:443', cfg) do |client|
+    client.write("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n") #=> 40
+    client.readline("\r\n\r\n") #=> see response
+  end
+
+puts(response)
 ```
 
 For more samples see [the samples dir](https://github.com/mblumtritt/tcp-client/tree/main/sample)

--- a/lib/tcp-client.rb
+++ b/lib/tcp-client.rb
@@ -201,6 +201,20 @@ class TCPClient
     end
   end
 
+  def readline(sep = $/, chomp: false, timeout: nil, exception: nil)
+    raise(NotConnectedError) if closed?
+    deadline = create_deadline(timeout, configuration.read_timeout)
+    unless deadline.valid?
+      return stem_errors { @socket.readline(sep, chomp: chomp) }
+    end
+    exception ||= configuration.read_timeout_error
+    line =
+      stem_errors(exception) do
+        @socket.readto_with_deadline(sep, deadline, exception)
+      end
+    chomp ? line.chomp : line
+  end
+
   #
   # @return [String] the currently used address as text.
   #

--- a/lib/tcp-client/configuration.rb
+++ b/lib/tcp-client/configuration.rb
@@ -56,7 +56,6 @@ class TCPClient
     # @option options [Boolean] :normalize_network_errors, see
     #   {#normalize_network_errors}
     #
-    #
     def initialize(options = {})
       @buffered = @keep_alive = @reverse_lookup = true
       self.timeout = @ssl_params = nil

--- a/lib/tcp-client/version.rb
+++ b/lib/tcp-client/version.rb
@@ -2,5 +2,5 @@
 
 class TCPClient
   # The current version number.
-  VERSION = '0.9.4'
+  VERSION = '0.10.0'
 end

--- a/lib/tcp-client/version.rb
+++ b/lib/tcp-client/version.rb
@@ -2,5 +2,5 @@
 
 class TCPClient
   # The current version number.
-  VERSION = '0.10.0'
+  VERSION = '0.10.0a'
 end

--- a/lib/tcp-client/version.rb
+++ b/lib/tcp-client/version.rb
@@ -2,5 +2,5 @@
 
 class TCPClient
   # The current version number.
-  VERSION = '0.10.0a'
+  VERSION = '0.10.0'
 end

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -6,8 +6,13 @@ require 'rspec/core/rake_task'
 require 'yard'
 
 $stdout.sync = $stderr.sync = true
+
 CLEAN << 'prj' << 'doc'
+
 CLOBBER << '.yardoc'
+
 task(:default) { exec('rake --tasks') }
+
 RSpec::Core::RakeTask.new { |task| task.ruby_opts = %w[-w] }
+
 YARD::Rake::YardocTask.new { |task| task.stats_options = %w[--list-undoc] }

--- a/sample/google_ssl.rb
+++ b/sample/google_ssl.rb
@@ -18,8 +18,11 @@ cfg =
 # - limit all network interactions to 1.5 seconds
 # - use the Configuration cfg
 # - send a simple HTTP get request
-# - read 12 byte: "HTTP/1.1 " + 3 byte HTTP status code
-TCPClient.with_deadline(1.5, 'www.google.com:443', cfg) do |client|
-  p client.write("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n")
-  p client.read(12)
-end
+# - read the returned message and headers
+response =
+  TCPClient.with_deadline(1.5, 'www.google.com:443', cfg) do |client|
+    client.write("GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n") #=> 40
+    client.readline("\r\n\r\n") #=> see response
+  end
+
+puts(response)

--- a/spec/tcp_client_spec.rb
+++ b/spec/tcp_client_spec.rb
@@ -274,11 +274,11 @@ RSpec.describe TCPClient do
           it 'reads chunk by chunk' do
             expect_any_instance_of(::Socket).to receive(:read_nonblock)
               .once
-              .with(data_size * 2, exception: false)
+              .with(instance_of(Integer), exception: false)
               .and_return(data)
             expect_any_instance_of(::Socket).to receive(:read_nonblock)
               .once
-              .with(data_size, exception: false)
+              .with(instance_of(Integer), exception: false)
               .and_return(data)
             expect(client.read(data_size * 2, timeout: 10)).to eq data * 2
           end
@@ -463,20 +463,16 @@ RSpec.describe TCPClient do
           .with(kind_of(String), exception: false)
         expect_any_instance_of(::Socket).to receive(:read_nonblock)
           .once
-          .with(12, exception: false)
-          .and_return('123456789012')
+          .with(instance_of(Integer), exception: false)
+          .and_return('123456789012abcdefgAB')
         expect_any_instance_of(::Socket).to receive(:write_nonblock)
           .once
           .with('123456', exception: false)
           .and_return(6)
         expect_any_instance_of(::Socket).to receive(:read_nonblock)
           .once
-          .with(7, exception: false)
-          .and_return('abcdefg')
-        expect_any_instance_of(::Socket).to receive(:read_nonblock)
-          .once
-          .with(7, exception: false)
-          .and_return('ABCDEFG')
+          .with(instance_of(Integer), exception: false)
+          .and_return('CDEFG')
         expect_any_instance_of(::Socket).to receive(:write_nonblock)
           .once
           .with('abc', exception: false)


### PR DESCRIPTION
- catch address related errors when `Configuration#normalize_network_errors` is true
- improve `#read` by using internal buffer
- add `#readline` method
- extend tests, include edge cases for `#read` and `#readline`
- extend sample in documentation
- bump version to v0.10.0