### PR TITLE
Version 0.12.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development, :test do
 end
 
 group :development do
-  gem 'prettier', require: false
+  gem 'prettier_print', require: false
   gem 'yard', require: false
 end
 

--- a/lib/tcp-client.rb
+++ b/lib/tcp-client.rb
@@ -226,7 +226,7 @@ class TCPClient
     raise(NotConnectedError) if closed?
     deadline = create_deadline(timeout, configuration.read_timeout)
     deadline.valid? or
-      return stem_errors { @socket.readline(separator, chomp: chomp) }
+      return stem_errors { @socket.readline(separator, chomp:) }
     exception ||= configuration.read_timeout_error
     line =
       stem_errors(exception) do

--- a/lib/tcp-client/address.rb
+++ b/lib/tcp-client/address.rb
@@ -83,7 +83,7 @@ class TCPClient
     # @return [Hash] host and port
     #
     def to_hash
-      { host: host, port: port }
+      { host:, port: }
     end
 
     #

--- a/lib/tcp-client/address.rb
+++ b/lib/tcp-client/address.rb
@@ -94,7 +94,7 @@ class TCPClient
     # @return [Hash] host and port
     #
     def to_h(&block)
-      block ? [[:host, host], [:port, port]].to_h(&block) : to_hash
+      block ? to_hash.to_h(&block) : to_hash
     end
 
     #
@@ -120,7 +120,7 @@ class TCPClient
 
     # @!visibility private
     def ==(other)
-      to_h == other.to_h
+      to_hash == other.to_h
     end
     alias eql? ==
 

--- a/lib/tcp-client/configuration.rb
+++ b/lib/tcp-client/configuration.rb
@@ -268,7 +268,7 @@ class TCPClient
     #
     # @see #configure
     #
-    def to_h
+    def to_hash
       {
         buffered: @buffered,
         keep_alive: @keep_alive,
@@ -282,6 +282,17 @@ class TCPClient
         write_timeout_error: @write_timeout_error,
         normalize_network_errors: @normalize_network_errors
       }
+    end
+
+    #
+    # @overload to_h
+    # @overload to_h(&block)
+    # @return [{Symbol => Object}] Hash containing all attributes
+    #
+    # @see #configure
+    #
+    def to_h(&block)
+      block ? to_hash.to_h(&block) : to_hash
     end
 
     #
@@ -326,7 +337,7 @@ class TCPClient
 
     # @!visibility private
     def ==(other)
-      to_h == other.to_h
+      to_hash == other.to_h
     end
     alias eql? ==
 

--- a/lib/tcp-client/default_configuration.rb
+++ b/lib/tcp-client/default_configuration.rb
@@ -31,8 +31,8 @@ class TCPClient
     #
     # @return [Configuration] the new default configuration
     #
-    def configure(options = nil, &block)
-      @default_configuration = Configuration.create(options, &block)
+    def configure(options = nil, &)
+      @default_configuration = Configuration.create(options, &)
     end
   end
 


### PR DESCRIPTION
- global tidy-up (syntax sugar)
- add `Config#to_hash` to support consistent use of `#to_h` and `#to_hash`